### PR TITLE
fix: EZSArray thread safe issue.

### DIFF
--- a/EasySequence/Classes/Sequences/EZSArray.m
+++ b/EasySequence/Classes/Sequences/EZSArray.m
@@ -82,14 +82,16 @@
 #pragma mark - remove methods
 
 - (void)removeLastObject {
-    if (self.count >= 1) {
-        [self removeObjectAtIndex:(self.count - 1)];
+    EZS_SCOPELOCK(_arrayLock);
+    if (_array.count > 0) {
+        [_array removeLastObject];
     }
 }
 
 - (void)removeFirstObject {
-    if (self.count > 0){
-        [self removeObjectAtIndex:0];
+    EZS_SCOPELOCK(_arrayLock);
+    if (_array.count > 0) {
+        [_array removeObjectAtIndex:0];
     }
 }
 


### PR DESCRIPTION
Class EZSArray methods `- removeLastObject` and `- removeFirstObject` have thread safe issue.

[close #17]
