### PR TITLE
fix: EZSOrderedSet thread safe issue.

### DIFF
--- a/EasySequence/Classes/Sequences/EZSOrderedSet.m
+++ b/EasySequence/Classes/Sequences/EZSOrderedSet.m
@@ -69,7 +69,8 @@
 #pragma mark - add methods
 
 - (void)addObject:(id)anObject {
-    [self insertObject:anObject atIndex:self.count];
+    EZS_SCOPELOCK(_orderedSetLock);
+    [_orderedSet addObject:anObject];
 }
 
 - (void)insertObject:(id)anObject atIndex:(NSUInteger)index {

--- a/EasySequence/Classes/Sequences/EZSOrderedSet.m
+++ b/EasySequence/Classes/Sequences/EZSOrderedSet.m
@@ -81,14 +81,16 @@
 #pragma mark - remove methods
 
 - (void)removeLastObject {
-    if (self.count >= 1) {
-        [self removeObjectAtIndex:(_orderedSet.count - 1)];
+    EZS_SCOPELOCK(_orderedSetLock);
+    if (_orderedSet.count > 0) {
+        [_orderedSet removeObjectAtIndex:_orderedSet.count - 1];
     }
 }
 
 - (void)removeFirstObject {
-    if (self.count > 0){
-        [self removeObjectAtIndex:0];
+    EZS_SCOPELOCK(_orderedSetLock);
+    if (_orderedSet.count > 0) {
+        [_orderedSet removeObjectAtIndex:0];
     }
 }
 

--- a/EasySequence/Classes/Sequences/EZSWeakOrderedSet.m
+++ b/EasySequence/Classes/Sequences/EZSWeakOrderedSet.m
@@ -57,6 +57,11 @@
 
 #pragma mark - add methods
 
+- (void)addObject:(id)anObject {
+    EZSWeakReference *obj = [self weakReference:anObject];
+    [super addObject:obj];
+}
+
 - (void)insertObject:(id)anObject atIndex:(NSUInteger)index {
     EZSWeakReference *obj = [self weakReference:anObject];
     [super insertObject:obj atIndex:index];


### PR DESCRIPTION
Class EZSOrderedSet methods `- removeLastObject` and `- removeFirstObject` have thread safe issue.

[#17]